### PR TITLE
Add origin input to name_lookup + minor documentation corrections

### DIFF
--- a/R/name_lookup.r
+++ b/R/name_lookup.r
@@ -79,6 +79,8 @@
 #' name_lookup(nameType = c("cultivar", "doubtful"))
 #' name_lookup(datasetKey = c("73605f3a-af85-4ade-bbc5-522bfb90d847",
 #'   "d7c60346-44b6-400d-ba27-8d3fbeffc8a5"))
+#' name_lookup(datasetKey = "289244ee-e1c1-49aa-b2d7-d379391ce265",
+#'   origin = c("SOURCE", "DENORMED_CLASSIFICATION"))
 #'
 #' # Pass on curl options
 #' name_lookup(query='Cnaemidophorus', rank="genus",

--- a/R/name_lookup.r
+++ b/R/name_lookup.r
@@ -87,7 +87,7 @@
 
 name_lookup <- function(query=NULL, rank=NULL, higherTaxonKey=NULL, status=NULL,
   isExtinct=NULL, habitat=NULL, nameType=NULL, datasetKey=NULL,
-  nomenclaturalStatus=NULL, limit=100, start=NULL, facet=NULL,
+  origin=NULL, nomenclaturalStatus=NULL, limit=100, start=NULL, facet=NULL,
   facetMincount=NULL, facetMultiselect=NULL, type=NULL, hl=NULL,
   verbose=FALSE, return="all", curlopts = list()) {
 
@@ -106,6 +106,7 @@ name_lookup <- function(query=NULL, rank=NULL, higherTaxonKey=NULL, status=NULL,
   habitat <- as_many_args(habitat)
   nameType <- as_many_args(nameType)
   datasetKey <- as_many_args(datasetKey)
+  origin <- as_many_args(origin)
 
   url <- paste0(gbif_base(), '/species/search')
   args <- rgbif_compact(list(q=query, isExtinct=as_log(isExtinct),
@@ -114,7 +115,7 @@ name_lookup <- function(query=NULL, rank=NULL, higherTaxonKey=NULL, status=NULL,
             facetMultiselect=as_log(facetMultiselect), hl=as_log(hl),
             type=type))
   args <- c(args, facetbyname, rank, higherTaxonKey, status,
-            habitat, nameType, datasetKey)
+            habitat, nameType, datasetKey, origin)
   tt <- gbif_GET(url, args, FALSE, curlopts)
 
   # metadata

--- a/R/name_usage.r
+++ b/R/name_usage.r
@@ -39,8 +39,9 @@
 #' # Name usage for a taxonomic name
 #' name_usage(name='Puma', rank="GENUS")
 #'
-#' # Name usage for all taxa in a dataset (set sufficient high limit)
-#' name_usage(datasetKey = "9ff7d317-609b-4c08-bd86-3bc404b77c42", limit = 100000)
+#' # Name usage for all taxa in a dataset 
+#' (set sufficient high limit, but less than 100000)
+#' name_usage(datasetKey = "9ff7d317-609b-4c08-bd86-3bc404b77c42", limit = 10000)
 #' # All name usages
 #' name_usage()
 #'

--- a/man-roxygen/namelkup.r
+++ b/man-roxygen/namelkup.r
@@ -43,6 +43,19 @@
 #'  nomenclatural rules.
 #' }
 #' @param datasetKey Filters by the dataset's key (a uuid)
+#' @param origin (character) Filters by origin. One of:
+#' \itemize{
+#'  \item SOURCE
+#'  \item DENORMED_CLASSIFICATION
+#'  \item VERBATIM_ACCEPTED
+#'  \item EX_AUTHOR_SYNONYM
+#'  \item AUTONYM
+#'  \item BASIONYM_PLACEHOLDER
+#'  \item MISSING_ACCEPTED
+#'  \item IMPLICIT_NAME
+#'  \item PROPARTE
+#'  \item VERBATIM_BASIONYM
+#' }
 #' @param nomenclaturalStatus	Not yet implemented, but will eventually allow
 #' for filtering by a nomenclatural status enum
 #' @param facet	A vector/list of facet names used to retrieve the 100 most
@@ -105,6 +118,7 @@
 #'  \item \strong{habitat}
 #'  \item \strong{nameType}
 #'  \item \strong{datasetKey}
+#'  \item \strong{origin}
 #' }
 #'
 #' see also \code{\link{many-values}}

--- a/man-roxygen/namelkup.r
+++ b/man-roxygen/namelkup.r
@@ -100,8 +100,8 @@
 #' \itemize{
 #'  \item \strong{metadata}
 #'  \item \strong{data}: either a data.frame (\code{verbose=FALSE}, default) or a list (\code{verbose=TRUE}).
-#'  \item \strong{hierarchy}
 #'  \item \strong{facets}
+#'  \item \strong{hierarchies}
 #'  \item \strong{names}
 #' }
 #'

--- a/man-roxygen/namelkup.r
+++ b/man-roxygen/namelkup.r
@@ -87,7 +87,7 @@
 #' element. If \code{FALSE} (default) a subset of the data that is thought to be most
 #' essential is organized into a data.frame.
 #'
-#' @param return One of data, meta, facets, names, or all. If data, a
+#' @param return One of data, meta, facets, hierarchy, names or all. If data, a
 #' data.frame with the data. facets returns the facets, if \code{facets=TRUE}, or
 #' empy list if \code{facets=FALSE}. meta returns the metadata for the entire call.
 #' names returns the vernacular (common) names for each taxon. all gives all
@@ -96,9 +96,11 @@
 #' matches the first column of the data.frame in the data slot. So if you
 #' wanted to combine those somehow, you could easily do so using the key.
 #'
-#' @return A list of length three. The first element is metadata. The second is
-#' either a data.frame (\code{verbose=FALSE}, default) or a list (\code{verbose=TRUE}),
-#' and the third element is the facet data.
+#' @return A list of length five. The first element is metadata. The second is
+#' either a data.frame (\code{verbose=FALSE}, default) or a list (\code{verbose=TRUE}).
+#' The third element is a list contatining the facet data.
+#' The fourth element is a list containing the hierarchies.
+#' The fifth element is a list containing the names.
 #'
 #' @description
 #' This service uses fuzzy lookup so that you can put in partial names and

--- a/man-roxygen/namelkup.r
+++ b/man-roxygen/namelkup.r
@@ -96,11 +96,14 @@
 #' matches the first column of the data.frame in the data slot. So if you
 #' wanted to combine those somehow, you could easily do so using the key.
 #'
-#' @return A list of length five. The first element is metadata. The second is
-#' either a data.frame (\code{verbose=FALSE}, default) or a list (\code{verbose=TRUE}).
-#' The third element is a list contatining the facet data.
-#' The fourth element is a list containing the hierarchies.
-#' The fifth element is a list containing the names.
+#' @return A list of length five:
+#' \itemize{
+#'  \item \strong{metadata}
+#'  \item \strong{data}: either a data.frame (\code{verbose=FALSE}, default) or a list (\code{verbose=TRUE}).
+#'  \item \strong{hierarchy}
+#'  \item \strong{facets}
+#'  \item \strong{names}
+#' }
 #'
 #' @description
 #' This service uses fuzzy lookup so that you can put in partial names and

--- a/man-roxygen/namelkup.r
+++ b/man-roxygen/namelkup.r
@@ -111,7 +111,7 @@
 #' ignored (facetOnly, facetMincount, facetMultiselect).
 #'
 #' @section Repeat parmeter inputs:
-#' Some parameters can tak emany inputs, and treated as 'OR' (e.g., a or b or
+#' Some parameters can take many inputs, and treated as 'OR' (e.g., a or b or
 #' c). The following take many inputs:
 #' \itemize{
 #'  \item \strong{rank}

--- a/man-roxygen/nameusage.r
+++ b/man-roxygen/nameusage.r
@@ -6,7 +6,7 @@
 #' SUBPHYLUM, SUBSECTION, SUBSERIES, SUBSPECIES, SUBTRIBE, SUBVARIETY,
 #' SUPERCLASS, SUPERFAMILY, SUPERORDER, SUPERPHYLUM, SUPRAGENERIC_NAME,
 #' TRIBE, UNRANKED, VARIETY
-#' @param datasetKey (character) Filters by the dataset's key (a uuid). must 
+#' @param datasetKey (character) Filters by the dataset's key (a uuid). Must
 #' be length=1
 #' @param key (numeric or character) A GBIF key for a taxon
 #' @param name (character) Filters by a case insensitive, canonical namestring,
@@ -16,17 +16,18 @@
 #' @param language (character) Language, default is english
 #' @param sourceId (numeric) Filters by the source identifier. Not used
 #' right now.
-#' @param shortname (character) A short name for a dataset - it may 
+#' @param shortname (character) A short name for a dataset - it may
 #' not do anything
-#' @param uuid (character) A datset key
+#' @param uuid (character) A dataset key
 #'
 #' @section Repeat parameter inputs:
 #' These parameters used to accept many inputs, but no longer do:
-#' 
+#'
 #' \itemize{
 #'  \item \strong{rank}
 #'  \item \strong{name}
 #'  \item \strong{langugae}
+#'  \item \strong{datasetKey}
 #' }
 #'
 #' see also \code{\link{many-values}}

--- a/man/name_lookup.Rd
+++ b/man/name_lookup.Rd
@@ -118,7 +118,7 @@ response.}
 element. If \code{FALSE} (default) a subset of the data that is thought to be most
 essential is organized into a data.frame.}
 
-\item{return}{One of data, meta, facets, names, hierarchy, or all. If data, a
+\item{return}{One of data, meta, facets, hierarchy, names or all. If data, a
 data.frame with the data. facets returns the facets, if \code{facets=TRUE}, or
 empy list if \code{facets=FALSE}. meta returns the metadata for the entire call.
 names returns the vernacular (common) names for each taxon. all gives all
@@ -132,9 +132,11 @@ wanted to combine those somehow, you could easily do so using the key.}
 for curl options}
 }
 \value{
-A list of length three. The first element is metadata. The second is
-either a data.frame (\code{verbose=FALSE}, default) or a list (\code{verbose=TRUE}),
-and the third element is the facet data.
+A list of length five. The first element is metadata. The second is
+either a data.frame (\code{verbose=FALSE}, default) or a list (\code{verbose=TRUE}).
+The third element is a list contatining the facet data.
+The fourth element is a list containing the hierarchies.
+The fifth element is a list containing the names.
 }
 \description{
 Lookup names in all taxonomies in GBIF.

--- a/man/name_lookup.Rd
+++ b/man/name_lookup.Rd
@@ -136,8 +136,8 @@ A list of length five:
 \itemize{
  \item \strong{metadata}
  \item \strong{data}: either a data.frame (\code{verbose=FALSE}, default) or a list (\code{verbose=TRUE}).
- \item \strong{hierarchy}
  \item \strong{facets}
+ \item \strong{hierarchies}
  \item \strong{names}
 }
 }

--- a/man/name_lookup.Rd
+++ b/man/name_lookup.Rd
@@ -6,8 +6,8 @@
 \usage{
 name_lookup(query = NULL, rank = NULL, higherTaxonKey = NULL,
   status = NULL, isExtinct = NULL, habitat = NULL, nameType = NULL,
-  datasetKey = NULL, nomenclaturalStatus = NULL, limit = 100,
-  start = NULL, facet = NULL, facetMincount = NULL,
+  datasetKey = NULL, origin = NULL, nomenclaturalStatus = NULL,
+  limit = 100, start = NULL, facet = NULL, facetMincount = NULL,
   facetMultiselect = NULL, type = NULL, hl = NULL, verbose = FALSE,
   return = "all", curlopts = list())
 }
@@ -65,6 +65,20 @@ or terrestrial}
 
 \item{datasetKey}{Filters by the dataset's key (a uuid)}
 
+\item{origin}{(character) Filters by origin. One of:
+\itemize{
+ \item SOURCE
+ \item DENORMED_CLASSIFICATION
+ \item VERBATIM_ACCEPTED
+ \item EX_AUTHOR_SYNONYM
+ \item AUTONYM
+ \item BASIONYM_PLACEHOLDER
+ \item MISSING_ACCEPTED
+ \item IMPLICIT_NAME
+ \item PROPARTE
+ \item VERBATIM_BASIONYM
+}}
+
 \item{nomenclaturalStatus}{Not yet implemented, but will eventually allow
 for filtering by a nomenclatural status enum}
 
@@ -104,7 +118,7 @@ response.}
 element. If \code{FALSE} (default) a subset of the data that is thought to be most
 essential is organized into a data.frame.}
 
-\item{return}{One of data, meta, facets, names, or all. If data, a
+\item{return}{One of data, meta, facets, names, hierarchy, or all. If data, a
 data.frame with the data. facets returns the facets, if \code{facets=TRUE}, or
 empy list if \code{facets=FALSE}. meta returns the metadata for the entire call.
 names returns the vernacular (common) names for each taxon. all gives all
@@ -143,6 +157,7 @@ c). The following take many inputs:
  \item \strong{habitat}
  \item \strong{nameType}
  \item \strong{datasetKey}
+ \item \strong{origin}
 }
 
 see also \code{\link{many-values}}
@@ -224,6 +239,8 @@ name_lookup(habitat = c("marine", "terrestrial"))
 name_lookup(nameType = c("cultivar", "doubtful"))
 name_lookup(datasetKey = c("73605f3a-af85-4ade-bbc5-522bfb90d847",
   "d7c60346-44b6-400d-ba27-8d3fbeffc8a5"))
+name_lookup(datasetKey = "289244ee-e1c1-49aa-b2d7-d379391ce265",
+  origin = c("SOURCE", "DENORMED_CLASSIFICATION"))
 
 # Pass on curl options
 name_lookup(query='Cnaemidophorus', rank="genus",

--- a/man/name_lookup.Rd
+++ b/man/name_lookup.Rd
@@ -150,7 +150,7 @@ ignored (facetOnly, facetMincount, facetMultiselect).
 }
 \section{Repeat parmeter inputs}{
 
-Some parameters can tak emany inputs, and treated as 'OR' (e.g., a or b or
+Some parameters can take many inputs, and treated as 'OR' (e.g., a or b or
 c). The following take many inputs:
 \itemize{
  \item \strong{rank}

--- a/man/name_lookup.Rd
+++ b/man/name_lookup.Rd
@@ -132,11 +132,14 @@ wanted to combine those somehow, you could easily do so using the key.}
 for curl options}
 }
 \value{
-A list of length five. The first element is metadata. The second is
-either a data.frame (\code{verbose=FALSE}, default) or a list (\code{verbose=TRUE}).
-The third element is a list contatining the facet data.
-The fourth element is a list containing the hierarchies.
-The fifth element is a list containing the names.
+A list of length five:
+\itemize{
+ \item \strong{metadata}
+ \item \strong{data}: either a data.frame (\code{verbose=FALSE}, default) or a list (\code{verbose=TRUE}).
+ \item \strong{hierarchy}
+ \item \strong{facets}
+ \item \strong{names}
+}
 }
 \description{
 Lookup names in all taxonomies in GBIF.

--- a/man/name_usage.Rd
+++ b/man/name_usage.Rd
@@ -103,8 +103,9 @@ name_usage(key=1)
 # Name usage for a taxonomic name
 name_usage(name='Puma', rank="GENUS")
 
-# Name usage for all taxa in a dataset (set sufficient high limit)
-name_usage(datasetKey = "9ff7d317-609b-4c08-bd86-3bc404b77c42", limit = 100000)
+# Name usage for all taxa in a dataset 
+(set sufficient high limit, but less than 100000)
+name_usage(datasetKey = "9ff7d317-609b-4c08-bd86-3bc404b77c42", limit = 10000)
 # All name usages
 name_usage()
 

--- a/man/name_usage.Rd
+++ b/man/name_usage.Rd
@@ -20,10 +20,10 @@ See Description below.}
 
 \item{language}{(character) Language, default is english}
 
-\item{datasetKey}{(character) Filters by the dataset's key (a uuid). must
+\item{datasetKey}{(character) Filters by the dataset's key (a uuid). Must
 be length=1}
 
-\item{uuid}{(character) A datset key}
+\item{uuid}{(character) A dataset key}
 
 \item{sourceId}{(numeric) Filters by the source identifier. Not used
 right now.}
@@ -89,6 +89,7 @@ These parameters used to accept many inputs, but no longer do:
  \item \strong{rank}
  \item \strong{name}
  \item \strong{langugae}
+ \item \strong{datasetKey}
 }
 
 see also \code{\link{many-values}}

--- a/tests/testthat/test-name_lookup.r
+++ b/tests/testthat/test-name_lookup.r
@@ -53,7 +53,7 @@ test_that("works with parameters that allow many inputs", {
   expect_true(all(
     unique(tolower(aa$data$taxonomicStatus)) %in% c("misapplied", "synonym")))
 
-  aa <- name_lookup(nameType = c("cultivar", "doubtful"))
+  aa <- name_lookup(nameType = c("cultivar", "doubtful"), limit = 200)
   expect_is(aa, "list")
   expect_is(aa$meta, "data.frame")
   expect_is(aa$meta$endOfRecords, "logical")
@@ -61,4 +61,13 @@ test_that("works with parameters that allow many inputs", {
   expect_is(aa$data$key, "integer")
   expect_true(all(
     unique(tolower(aa$data$nameType)) %in% c("cultivar", "doubtful")))
+
+  aa <- name_lookup(origin = c("implicit_name", "proparte"), limit = 250)
+  expect_is(aa, "list")
+  expect_is(aa$meta, "data.frame")
+  expect_is(aa$meta$endOfRecords, "logical")
+  expect_is(aa$data$canonicalName, "character")
+  expect_is(aa$data$key, "integer")
+  expect_true(all(
+    unique(tolower(aa$data$origin)) %in% c("implicit_name", "proparte")))
 })


### PR DESCRIPTION
## Description
I added parameter `origin` to `name_lookup(...)`. Documentation has been updated as well. 
This PR should not be accepted: no merge! It is intended to provide an internal review before PR to `ropensci/rgbif/master`.

## Related Issue
This PR should tackle the issue described by @peterdesmet  in #288.
Please notice that at this moment it is not possible to implement `origin` in `name_usage()` because GBIF API doesn't support `origin` in [https://api.gbif.org/v1/species?](). It works only in [https://api.gbif.org/v1/species/search?](). Please, see my comment on #288.
## Examples
```r
only_source <- name_lookup(datasetKey = "289244ee-e1c1-49aa-b2d7-d379391ce265", 
  origin = "SOURCE", return = "data", limit = 200)
nrow(only_source)
```
```r
denormed_classification <- name_lookup(datasetKey = "289244ee-e1c1-49aa-b2d7-d379391ce265",
  origin = "DENORMED_CLASSIFICATION", return = "data")
nrow(denormed_classification)
```
```r
source_denormed_classification <- name_lookup(datasetKey = "289244ee-e1c1-49aa-b2d7-d379391ce265",
  origin = c("SOURCE", "DENORMED_CLASSIFICATION"), return = "data", limit = 200)
nrow(source_denormed_classification)
```
```r
all_records <- name_lookup(datasetKey = "289244ee-e1c1-49aa-b2d7-d379391ce265", 
  return = "data", limit = 200)
nrow(all_records)
```
```r
library(dplyr)
library(magrittr)
source_denormed_classification %<>% arrange(key)
all_records %<>% arrange(key)
all(source_denormed_classification == all_records, na.rm = TRUE)
```